### PR TITLE
Batched dispatching

### DIFF
--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -27,32 +27,40 @@ function getDelayedDispatch(dispatcher) {
 
   const queue = []
 
+  function drainQueue() {
+    let state = dispatcher._reduxGetState(),
+      i
+
+    for (i = 0; i < 100 && (i <= queue.length - 1); i++) {
+      // for-real dispatch the last action, triggering redux's subscribe
+      // (and thus UI re-renders). This prioritises crunching data over
+      // feedback, but potentially we should dispatch perodically, even
+      // with items in the queue
+      if (i < queue.length - 1) {
+        state = dispatcher._historyReducer(state, queue[i])
+      } else {
+        // unsure of delaying the dispatch itself is a net gain.
+        // requestAnimationFrame(
+        //   ((action) => () => dispatcher._reduxDispatch(action))(queue[i])
+        // )
+
+        dispatcher._reduxDispatch(queue[i])
+      }
+    }
+
+    // reset the queue
+    queue.splice(0, i + 1)
+
+    if (queue.length)
+      requestAnimationFrame(drainQueue)
+  }
+
   return function delayedDispatch(action) {
     queue.push(action)
 
     // on first action, queue dispatching the action queue
     if (queue.length === 1) {
-      requestAnimationFrame(() => {
-        let state = dispatcher._reduxGetState(),
-          i
-
-        for (i = 0; i <= queue.length - 1; i++) {
-          // for-real dispatch the last action, triggering redux's subscribe
-          // (and thus UI re-renders). This prioritises crunching data over
-          // feedback, but potentially we should dispatch perodically, even
-          // with items in the queue
-          if (i < queue.length - 2) {
-            state = dispatcher._historyReducer(state, queue[i])
-          } else {
-            dispatcher._reduxDispatch(queue[i])
-          }
-        }
-
-        console.log('emptying action queue of', queue.length, 'dispatched', i)
-
-        // reset the queue
-        queue.splice(0, i + 1)
-      })
+      requestAnimationFrame(drainQueue)
     }
   }
 }

--- a/src/orderedHistory.js
+++ b/src/orderedHistory.js
@@ -77,20 +77,6 @@ export const reducer = (reducer) => (currentState = [], action) => {
     //   thisAction, thisState[STATE_TIMESTAMP], thisAction === action)
 
     thisState[STATE_SNAPSHOT] = reducer(lastSnapshot, thisAction)
-
-    // debug: add a checksum of the ordered timestamps to the store
-    if (typeof window !== 'undefined') {
-      function checksum(arr) {
-        var chk = 0x12345678;
-
-        for (let i = 0; i < arr.length && !isNaN(arr[i]); i++) {
-          chk += (arr[i] * (i + 1));
-        }
-
-        return chk;
-      }
-      window.__checksum = checksum(currentState.map(state => state[STATE_TIMESTAMP]))
-    }
   }
 
   // if we're here, the currentState history has been updated

--- a/src/server.js
+++ b/src/server.js
@@ -17,6 +17,12 @@ export default function scuttlebuttServer(server) {
       gossipStream = gossip.createStream()
 
   const statistics = {}
+
+  // prime statistics for when spark.id is undefined, presumably server messages
+  statistics[undefined] = {
+    recv: 0, sent: 0, s: 'connected'
+  }
+
   setInterval(() => {
     for (let spark in statistics) {
       console.log(`${spark}: ${statistics[spark].recv} recv ${statistics[spark].sent} sent (${statistics[spark].s})`)


### PR DESCRIPTION
This branch reduces the number of calls to Redux's `dispatch` by reducing state (up to 99 actions at once) and finally dispatching the final event, which (due to the TimeTravel base reducer) will fire `subscribe` handlers with the final and correct state.
