### PR TITLE
Added devToolsStateSanitizer with examples

### DIFF
--- a/examples/chat/index.js
+++ b/examples/chat/index.js
@@ -3,11 +3,15 @@ import ReactDOM from 'react-dom'
 import { createStore, compose, applyMiddleware } from 'redux'
 import App from './components/App'
 import counter from './reducers'
-import scuttlebutt from 'redux-scuttlebutt'
+import scuttlebutt, { devToolsStateSanitizer } from 'redux-scuttlebutt'
+
+const devToolsConfig = {
+  stateSanitizer: devToolsStateSanitizer
+}
 
 const enhancer = compose(
   applyMiddleware(scuttlebutt),
-  window.devToolsExtension ? window.devToolsExtension() : f => f,
+  window.devToolsExtension ? window.devToolsExtension(devToolsConfig) : f => f,
 )
 
 const store = createStore(counter, undefined, enhancer)

--- a/examples/counter/index.js
+++ b/examples/counter/index.js
@@ -4,11 +4,15 @@ import { createStore, compose, applyMiddleware } from 'redux'
 import Counter from './components/Counter'
 import App from './components/App'
 import counter from './reducers'
-import scuttlebutt from 'redux-scuttlebutt'
+import scuttlebutt, { devToolsStateSanitizer } from 'redux-scuttlebutt'
+
+const devToolsConfig = {
+  stateSanitizer: devToolsStateSanitizer
+}
 
 const enhancer = compose(
   scuttlebutt(),
-  window.devToolsExtension ? window.devToolsExtension() : f => f,
+  window.devToolsExtension ? window.devToolsExtension(devToolsConfig) : f => f,
 )
 
 const store = createStore(counter, undefined, enhancer)

--- a/src/index.js
+++ b/src/index.js
@@ -134,3 +134,8 @@ function connectStreams(io, createStream) {
   })
 
 }
+
+// devToolsStateSanitizer can be applied to the devToolsExtension
+// as the stateSanitizer to show correctly the store state instead
+// of showing the internal representation of redux-scuttlebutt
+export const devToolsStateSanitizer = (state) => state.slice(-1)[0][3]


### PR DESCRIPTION
### The problem

redux-scuttlebutt made the use of the redux devtools extension more painful, because it shows the internal representation of redux-scuttlebutt (the array of actions and states) and you'd have to go to the last item in the array and the last item of that item (the state) to view the state.

### The solution

Thanks to redux-devtools-extension configuration options, we can add a `stateSanitizer` that prepares the state to show in the Monitor.

### Use

The examples show how to use the devToolsStateSanitizer, but just to give you a peak:
```es6
import scuttlebutt, { devToolsStateSanitizer } from 'redux-scuttlebutt'

const devToolsConfig = {
  stateSanitizer: devToolsStateSanitizer
}

const enhancer = compose(
  scuttlebutt(),
  window.devToolsExtension ? window.devToolsExtension(devToolsConfig) : f => f,
)

const store = createStore(reducer, undefined, enhancer)
```